### PR TITLE
fixed bug with dragging image anywhere in the div with id='dropZone'

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -59,6 +59,7 @@
       });
 
       dropZone.addEventListener("dragover", function (e) {
+        e.preventDefault();
         this.classList.add("dragover");
       });
 


### PR DESCRIPTION
<div> with id='dropZone' had the default behavior of only opening the image in the new tab instead of adding the image to upload. Adding this piece of code in 'dragover' event fixes this problem