### PR TITLE
Copy training weights from remote URL during image build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM python:3.9
 
 # download this https://github.com/danielgatis/rembg/releases/download/v0.0.0/u2net.onnx
-# copy model to avoid unnecessary download
-COPY u2net.onnx /home/.u2net/u2net.onnx
+ADD https://github.com/danielgatis/rembg/releases/download/v0.0.0/u2net.onnx /root/.u2net/u2net.onnx
 
 WORKDIR /app
 


### PR DESCRIPTION
This commit changes the `Dockerfile` so that the training weights are fetched during the image build. This saves users the intermediate step of manually downloading the weights file then building the image.