### PR TITLE
Fix repeated file input dialog trigger on click

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -49,7 +49,9 @@
       let uploadForm = document.getElementById("uploadForm");
 
       dropZone.addEventListener("click", function () {
+        if (e.target === dropZone) {
         fileInput.click();
+      }
       });
 
       fileInput.addEventListener("change", function () {
@@ -59,6 +61,7 @@
       });
 
       dropZone.addEventListener("dragover", function (e) {
+        e.preventDefault();
         this.classList.add("dragover");
       });
 


### PR DESCRIPTION
Fixed: upon manually selecting a file for upload, the file selection dialog would erroneously prompt the user to select a file again